### PR TITLE
Fix service worker build paths for deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+plan-kit-pwa/node_modules
+plan-kit-pwa/dist
+.DS_Store

--- a/PlanKitCapture/README.md
+++ b/PlanKitCapture/README.md
@@ -1,0 +1,13 @@
+# PlanKit Capture Helper
+
+A lightweight SwiftUI application built on top of RoomPlan to capture a single room and export JSON compatible with the PlanKit PWA.
+
+## Features
+
+- Start/stop RoomPlan capture with live preview.
+- Export JSON containing wall geometry, openings, and metadata.
+- Share JSON through the iOS Share Sheet or upload to the PWA backend when available.
+
+## Running
+
+Open the Xcode project and run on an iOS device with a LiDAR sensor (iPhone Pro or iPad Pro). The project assumes the `RoomPlan` capability is enabled.

--- a/PlanKitCapture/Sources/App.swift
+++ b/PlanKitCapture/Sources/App.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct PlanKitCaptureApp: App {
+    @StateObject private var manager = RoomPlanManager()
+
+    var body: some Scene {
+        WindowGroup {
+            CaptureView()
+                .environmentObject(manager)
+        }
+    }
+}

--- a/PlanKitCapture/Sources/CaptureView.swift
+++ b/PlanKitCapture/Sources/CaptureView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import RoomPlan
+
+struct CaptureView: View {
+    @EnvironmentObject var manager: RoomPlanManager
+    @State private var showShare = false
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("PlanKit Capture Helper")
+                .font(.title)
+                .bold()
+            Text("Scan one room at a time. On finish, export JSON to the PlanKit PWA or share locally.")
+                .multilineTextAlignment(.center)
+            Spacer()
+            RoomCaptureViewRepresentable(session: manager.session)
+                .frame(height: 400)
+                .cornerRadius(16)
+            Spacer()
+            HStack {
+                Button(action: manager.startCapturing) {
+                    Label("Start", systemImage: "camera")
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button("Finish") {
+                    Task {
+                        await manager.finishCapture()
+                        showShare = true
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(manager.exportState != .capturing)
+            }
+            if let json = manager.lastJson {
+                ShareLink(item: json, preview: SharePreview("PlanKit Room", image: Image(systemName: "square.grid.3x3")))
+                    .opacity(showShare ? 1 : 0)
+            }
+            Spacer()
+            if case .failed(let message) = manager.exportState {
+                Text("Export failed: \(message)")
+                    .foregroundColor(.red)
+            }
+        }
+        .padding()
+    }
+}
+
+struct RoomCaptureViewRepresentable: UIViewRepresentable {
+    let session: RoomCaptureSession
+
+    func makeUIView(context: Context) -> RoomCaptureView {
+        let view = RoomCaptureView(frame: .zero)
+        view.captureSession = session
+        return view
+    }
+
+    func updateUIView(_ uiView: RoomCaptureView, context: Context) {
+        uiView.captureSession = session
+    }
+}

--- a/PlanKitCapture/Sources/ExportMapper.swift
+++ b/PlanKitCapture/Sources/ExportMapper.swift
@@ -1,0 +1,77 @@
+import Foundation
+import RoomPlan
+
+struct ExportMapper {
+    struct Opening: Codable {
+        let type: String
+        let width_mm: Double
+        let height_mm: Double?
+        let sill_height_mm: Double?
+        let position_along_wall_mm: Double
+        let swing: String?
+    }
+
+    struct Wall: Codable {
+        let start: Point
+        let end: Point
+        let thickness_mm: Double
+        let openings: [Opening]
+    }
+
+    struct Point: Codable {
+        let x: Double
+        let y: Double
+    }
+
+    struct Room: Codable {
+        let name: String?
+        let height_m: Double?
+        let walls: [Wall]
+    }
+
+    struct Payload: Codable {
+        let room: Room
+    }
+
+    func jsonData(from data: CapturedRoomData) throws -> Data {
+        let walls = data.room.walls.map { wall -> Wall in
+            let openings = wall.openings.map { opening -> Opening in
+                let swing: String?
+                switch opening.type {
+                case .door(let door):
+                    swing = door.opensInwards ? "L" : "R"
+                case .opening:
+                    swing = nil
+                case .window:
+                    swing = "fixed"
+                @unknown default:
+                    swing = nil
+                }
+                return Opening(
+                    type: opening.kind.rawValue,
+                    width_mm: opening.dimensions.width * 1000.0,
+                    height_mm: opening.dimensions.height * 1000.0,
+                    sill_height_mm: opening.dimensions.bottom * 1000.0,
+                    position_along_wall_mm: opening.position.x * 1000.0,
+                    swing: swing
+                )
+            }
+
+            return Wall(
+                start: Point(x: wall.start.x * 1000.0, y: wall.start.z * 1000.0),
+                end: Point(x: wall.end.x * 1000.0, y: wall.end.z * 1000.0),
+                thickness_mm: wall.thickness * 1000.0,
+                openings: openings
+            )
+        }
+
+        let room = Room(
+            name: data.room.identifier,
+            height_m: data.room.height,
+            walls: walls
+        )
+
+        let payload = Payload(room: room)
+        return try JSONEncoder().encode(payload)
+    }
+}

--- a/PlanKitCapture/Sources/RoomPlanManager.swift
+++ b/PlanKitCapture/Sources/RoomPlanManager.swift
@@ -1,0 +1,52 @@
+import Foundation
+import RoomPlan
+
+@MainActor
+final class RoomPlanManager: ObservableObject {
+    @Published var session: RoomCaptureSession
+    @Published var captureEnabled = false
+    @Published var exportState: ExportState = .idle
+    @Published var lastJson: String?
+
+    enum ExportState {
+        case idle
+        case capturing
+        case exporting
+        case finished
+        case failed(String)
+    }
+
+    init() {
+        session = RoomCaptureSession()
+    }
+
+    func startCapturing() {
+        session = RoomCaptureSession()
+        session.delegate = self
+        captureEnabled = true
+        exportState = .capturing
+        session.run(configuration: RoomCaptureSession.Configuration())
+    }
+
+    func finishCapture() async {
+        exportState = .exporting
+        do {
+            let data = try await session.captureData
+            let mapper = ExportMapper()
+            let jsonData = try mapper.jsonData(from: data)
+            let jsonString = String(data: jsonData, encoding: .utf8)
+            lastJson = jsonString
+            exportState = .finished
+        } catch {
+            exportState = .failed(error.localizedDescription)
+        }
+    }
+}
+
+extension RoomPlanManager: RoomCaptureSessionDelegate {
+    func captureSession(_ session: RoomCaptureSession, didUpdate: CapturedRoom) {}
+    func captureSession(_ session: RoomCaptureSession, didAdd: CapturedRoom) {}
+    func captureSession(_ session: RoomCaptureSession, didRemove: CapturedRoom) {}
+
+    func captureSession(_ session: RoomCaptureSession, didEndWith data: CapturedRoomData, error: Error?) {}
+}

--- a/PlanKitCapture/Sources/Uploader.swift
+++ b/PlanKitCapture/Sources/Uploader.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+@MainActor
+final class Uploader {
+    struct Response: Decodable { let token: String }
+
+    func upload(json: String) async throws -> String {
+        guard let data = json.data(using: .utf8) else {
+            throw URLError(.badServerResponse)
+        }
+        guard let url = URL(string: "https://app.plankit.dev/api/upload") else {
+            throw URLError(.badURL)
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = data
+        let (body, _) = try await URLSession.shared.data(for: request)
+        let response = try JSONDecoder().decode(Response.self, from: body)
+        return response.token
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# Floorplanapp
+# PlanKit Monorepo
+
+This repository contains two deliverables that work together to produce editable, RoomPlan-powered floor plans:
+
+1. **plan-kit-pwa** – A Vite + React Progressive Web App that manages projects, imports RoomPlan JSON, stitches rooms, renders an editable Konva canvas, and exports deliverables (PDF/SVG/DXF/CSV).
+2. **PlanKitCapture** – A SwiftUI + RoomPlan helper that captures LiDAR rooms on iPhone/iPad and exports JSON that feeds the PWA import flow.
+
+## PlanKit PWA
+
+Navigate to `plan-kit-pwa/` and install dependencies:
+
+```bash
+npm install
+npm run dev
+```
+
+The application is offline-first using Dexie + Workbox, and includes a mock Express server (`server/mockImportServer.ts`) to simulate the optional upload token flow.
+
+Key features:
+
+- Project CRUD with IndexedDB persistence
+- RoomPlan JSON import mapper and fixture
+- Stitch assistant that computes transforms from shared openings
+- Konva-based editor with grid, zoom, and wall metrics
+- Export modules for SVG, PDF, DXF, and CSV schedules
+
+## iOS Capture Helper
+
+The `PlanKitCapture` folder contains SwiftUI sources for an iOS 17+ app leveraging RoomPlan. Build the app in Xcode, run on a LiDAR-capable device, scan a room, then export the generated JSON via Share Sheet or by uploading to the PWA when the optional backend is enabled.
+
+## Development workflow
+
+1. Capture a room on the iOS helper and export the JSON.
+2. In the PWA, create a new project and import the JSON.
+3. Use the Stitch tab to align rooms across shared openings.
+4. Switch to Edit to fine tune geometry and review metrics.
+5. Export deliverables (PDF/SVG/DXF/CSV) for downstream CAD/BIM tools.

--- a/plan-kit-pwa/README.md
+++ b/plan-kit-pwa/README.md
@@ -1,0 +1,30 @@
+# PlanKit PWA
+
+PlanKit is an offline-first floor plan editor that stitches together RoomPlan captures collected via the companion iOS helper. This project was bootstrapped with Vite + React + TypeScript and implements the core flows described in the product brief: project management, RoomPlan imports, stitching, editing, and exports (PDF, SVG, DXF, CSV).
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+The app registers a Workbox-powered service worker during production builds. Run `npm run build` followed by `npm run preview` to test the install prompt locally.
+
+## Project structure
+
+- `src/app` – Top-level routing and shell
+- `src/features/import` – Room import UI and token flow
+- `src/features/stitch` – Multi-room alignment assistant
+- `src/features/editor` – Canvas-based plan editor built with Konva
+- `src/features/export` – Export actions for PDF, SVG, DXF, CSV
+- `src/lib` – Geometry helpers, import mappers, and exporter utilities
+- `src/store` – IndexedDB persistence built with Dexie + Zustand
+
+## Offline data
+
+Projects are stored in IndexedDB via Dexie. The persisted Zustand slice keeps the last opened project in memory to enable instant reloads.
+
+## Exports
+
+The export modules produce simplified but functional outputs that exercise pdf-lib, dxf-writer, and native SVG generation. They act as foundations for richer title blocks and layer metadata.

--- a/plan-kit-pwa/index.html
+++ b/plan-kit-pwa/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#1f2937" />
+    <title>PlanKit</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/plan-kit-pwa/package.json
+++ b/plan-kit-pwa/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "plan-kit-pwa",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "dexie": "^4.0.4",
+    "dxf-writer": "^1.0.5",
+    "konva": "^9.3.14",
+    "pdf-lib": "^1.17.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.1",
+    "zustand": "^4.5.2",
+    "react-konva": "^18.2.8",
+    "express": "^4.19.2",
+    "cors": "^2.8.5",
+    "workbox-precaching": "^7.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.4.5",
+    "vite": "^5.1.6",
+    "vite-plugin-pwa": "^0.17.5"
+  }
+}

--- a/plan-kit-pwa/public/manifest.json
+++ b/plan-kit-pwa/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "PlanKit",
+  "short_name": "PlanKit",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#1f2937",
+  "description": "Offline-first floor plan editor for RoomPlan captures",
+  "icons": [
+    {
+      "src": "icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/plan-kit-pwa/server/mockImportServer.ts
+++ b/plan-kit-pwa/server/mockImportServer.ts
@@ -1,0 +1,34 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+app.use(express.json({ limit: '1mb' }));
+app.use(cors({ origin: 'https://app.plankit.dev', credentials: false }));
+
+const tokens = new Map<string, unknown>();
+
+function generateToken() {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+app.post('/api/upload', (req, res) => {
+  const token = generateToken();
+  tokens.set(token, req.body);
+  res.json({ token });
+});
+
+app.get('/api/import/:token', (req, res) => {
+  const { token } = req.params;
+  if (!tokens.has(token)) {
+    res.status(404).json({ error: 'Token not found' });
+    return;
+  }
+  const payload = tokens.get(token);
+  tokens.delete(token);
+  res.json(payload);
+});
+
+const port = process.env.PORT ? Number(process.env.PORT) : 8787;
+app.listen(port, () => {
+  console.log(`Mock upload server listening on ${port}`);
+});

--- a/plan-kit-pwa/src/app/App.tsx
+++ b/plan-kit-pwa/src/app/App.tsx
@@ -1,0 +1,15 @@
+import { Route, Routes } from 'react-router-dom';
+import { ProjectsList } from '../features/import/ProjectsList';
+import { PlanWorkspace } from '../features/editor/PlanWorkspace';
+import { AppShell } from './AppShell';
+
+export function App() {
+  return (
+    <AppShell>
+      <Routes>
+        <Route path="/" element={<ProjectsList />} />
+        <Route path="/plan/:id/*" element={<PlanWorkspace />} />
+      </Routes>
+    </AppShell>
+  );
+}

--- a/plan-kit-pwa/src/app/AppShell.tsx
+++ b/plan-kit-pwa/src/app/AppShell.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren } from 'react';
+import { Link } from 'react-router-dom';
+
+export function AppShell({ children }: PropsWithChildren) {
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <Link to="/" className="brand">
+          PlanKit
+        </Link>
+        <nav>
+          <Link to="/">Projects</Link>
+        </nav>
+      </header>
+      <main className="app-main">{children}</main>
+    </div>
+  );
+}

--- a/plan-kit-pwa/src/app/registerServiceWorker.ts
+++ b/plan-kit-pwa/src/app/registerServiceWorker.ts
@@ -1,0 +1,11 @@
+export async function registerServiceWorker() {
+  if ('serviceWorker' in navigator) {
+    try {
+      const swUrl = new URL('service-worker.js', import.meta.env.BASE_URL).toString();
+      const registration = await navigator.serviceWorker.register(swUrl);
+      console.info('Service worker registered', registration);
+    } catch (error) {
+      console.warn('Service worker registration failed', error);
+    }
+  }
+}

--- a/plan-kit-pwa/src/features/editor/PlanWorkspace.tsx
+++ b/plan-kit-pwa/src/features/editor/PlanWorkspace.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useMemo, useState } from 'react';
+import { NavLink, Route, Routes, useNavigate, useParams } from 'react-router-dom';
+import { useProjectsStore } from '../../store/useProjectsStore';
+import { ImportRoomPanel } from '../import/ImportRoomPanel';
+import { StitchAssistant } from '../stitch/StitchAssistant';
+import { CanvasWorkspace } from './canvas/CanvasWorkspace';
+import { ExportPanel } from '../export/ExportPanel';
+
+export function PlanWorkspace() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { projects, loadProjects, currentPlan, setCurrentPlan } = useProjectsStore();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    async function ensureProject() {
+      if (!projects.length) {
+        await loadProjects();
+      }
+      const plan = projects.find((p) => p.id === id);
+      if (plan) {
+        setCurrentPlan(plan);
+        setReady(true);
+      } else {
+        navigate('/');
+      }
+    }
+    ensureProject();
+  }, [projects, loadProjects, id, navigate, setCurrentPlan]);
+
+  const tabs = useMemo(
+    () => [
+      { to: '', label: 'Import', element: <ImportRoomPanel />, index: true },
+      { to: 'stitch', label: 'Stitch', element: <StitchAssistant /> },
+      { to: 'edit', label: 'Edit', element: <CanvasWorkspace /> },
+      { to: 'export', label: 'Export', element: <ExportPanel /> }
+    ],
+    []
+  );
+
+  if (!ready || !currentPlan) {
+    return <p>Loading plan…</p>;
+  }
+
+  return (
+    <div className="workspace">
+      <header className="workspace-header">
+        <h1>{currentPlan.label}</h1>
+        <p className="workspace-meta">
+          Updated {new Date(currentPlan.meta.updatedAt).toLocaleString()}
+        </p>
+      </header>
+      <nav className="workspace-tabs">
+        {tabs.map((tab) => (
+          <NavLink
+            key={tab.label}
+            to={tab.to}
+            end={tab.to === ''}
+            className={({ isActive }) => (isActive ? 'active' : undefined)}
+          >
+            {tab.label}
+          </NavLink>
+        ))}
+      </nav>
+      <div className="workspace-content">
+        <Routes>
+          {tabs.map((tab) =>
+            tab.index ? (
+              <Route key={tab.label} index element={tab.element} />
+            ) : (
+              <Route key={tab.label} path={tab.to} element={tab.element} />
+            )
+          )}
+        </Routes>
+      </div>
+    </div>
+  );
+}

--- a/plan-kit-pwa/src/features/editor/canvas/CanvasWorkspace.tsx
+++ b/plan-kit-pwa/src/features/editor/canvas/CanvasWorkspace.tsx
@@ -1,0 +1,93 @@
+import { useMemo, useState } from 'react';
+import { Layer, Line, Stage } from 'react-konva';
+import Konva from 'konva';
+import { applyTransformToRoom } from '../../../lib/geometry/transforms';
+import { lineLength } from '../../../lib/geometry/vector';
+import { useProjectsStore } from '../../../store/useProjectsStore';
+
+const GRID_SPACING = 500;
+
+export function CanvasWorkspace() {
+  const { currentPlan } = useProjectsStore();
+  const [scale, setScale] = useState(0.05); // 1 mm = 0.05 px => 1 m = 50 px
+
+  const rooms = useMemo(() => {
+    if (!currentPlan) return [];
+    return currentPlan.rooms.map((room) => {
+      const transform = currentPlan.transforms[room.id];
+      return transform ? applyTransformToRoom(room, transform) : room;
+    });
+  }, [currentPlan]);
+
+  if (!currentPlan) {
+    return <p>Select a project to edit.</p>;
+  }
+
+  function handleWheel(event: Konva.KonvaEventObject<WheelEvent>) {
+    event.evt.preventDefault();
+    const delta = event.evt.deltaY;
+    setScale((prev) => Math.min(0.2, Math.max(0.02, prev - delta * 0.0005)));
+  }
+
+  const width = 1200;
+  const height = 800;
+
+  const gridLines = [] as JSX.Element[];
+  for (let x = 0; x < width; x += GRID_SPACING * scale) {
+    gridLines.push(
+      <Line
+        key={`vx-${x}`}
+        points={[x, 0, x, height]}
+        stroke="#e2e8f0"
+        strokeWidth={1}
+      />
+    );
+  }
+  for (let y = 0; y < height; y += GRID_SPACING * scale) {
+    gridLines.push(
+      <Line
+        key={`hz-${y}`}
+        points={[0, y, width, y]}
+        stroke="#e2e8f0"
+        strokeWidth={1}
+      />
+    );
+  }
+
+  return (
+    <div className="canvas-workspace">
+      <div className="toolbar card">
+        <strong>Scale:</strong> {(scale * 1000).toFixed(0)} px / m
+      </div>
+      <Stage width={width} height={height} scaleX={scale} scaleY={scale} onWheel={handleWheel}>
+        <Layer>{gridLines}</Layer>
+        <Layer>
+          {rooms.map((room) => (
+            <Line
+              key={room.id}
+              points={room.walls.flatMap((wall) => [wall.start.x, wall.start.y, wall.end.x, wall.end.y])}
+              stroke="#1f2937"
+              strokeWidth={room.walls[0]?.thickness_mm ?? 120}
+              lineCap="round"
+              lineJoin="round"
+              closed
+            />
+          ))}
+        </Layer>
+      </Stage>
+      <aside className="card room-metrics">
+        <h3>Metrics</h3>
+        <ul>
+          {rooms.map((room) => {
+            const perimeter = room.walls.reduce((sum, wall) => sum + lineLength(wall.start, wall.end), 0);
+            return (
+              <li key={room.id}>
+                {room.name ?? 'Room'} – {Math.round(perimeter)} mm perimeter
+              </li>
+            );
+          })}
+        </ul>
+      </aside>
+    </div>
+  );
+}

--- a/plan-kit-pwa/src/features/export/ExportPanel.tsx
+++ b/plan-kit-pwa/src/features/export/ExportPanel.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { saveAs } from '../../lib/exporters/saveAs';
+import { exportAsSvg } from '../../lib/exporters/svg';
+import { exportAsCsv } from '../../lib/exporters/csv';
+import { exportAsPdf } from '../../lib/exporters/pdf';
+import { exportAsDxf } from '../../lib/exporters/dxf';
+import { useProjectsStore } from '../../store/useProjectsStore';
+
+export function ExportPanel() {
+  const { currentPlan } = useProjectsStore();
+  const [status, setStatus] = useState('Select an export format.');
+
+  if (!currentPlan) {
+    return <p>No plan selected.</p>;
+  }
+
+  async function handleExport(kind: 'svg' | 'pdf' | 'dxf' | 'csv') {
+    try {
+      setStatus(`Exporting ${kind.toUpperCase()}…`);
+      const blob =
+        kind === 'svg'
+          ? await exportAsSvg(currentPlan)
+          : kind === 'csv'
+          ? await exportAsCsv(currentPlan)
+          : kind === 'pdf'
+          ? await exportAsPdf(currentPlan)
+          : await exportAsDxf(currentPlan);
+      saveAs(blob, `${currentPlan.label ?? 'plan'}-${kind}.${kind === 'pdf' ? 'pdf' : kind}`);
+      setStatus(`Exported ${kind.toUpperCase()} successfully.`);
+    } catch (error) {
+      console.error(error);
+      setStatus('Export failed. Please check the console for details.');
+    }
+  }
+
+  return (
+    <section className="card export-panel">
+      <h2>Export</h2>
+      <p>Generate deliverables with preset layers and metadata.</p>
+      <div className="actions">
+        <button className="primary" onClick={() => handleExport('pdf')}>
+          PDF
+        </button>
+        <button className="secondary" onClick={() => handleExport('svg')}>
+          SVG
+        </button>
+        <button className="secondary" onClick={() => handleExport('dxf')}>
+          DXF
+        </button>
+        <button className="secondary" onClick={() => handleExport('csv')}>
+          CSV Schedules
+        </button>
+      </div>
+      <p className="status">{status}</p>
+    </section>
+  );
+}

--- a/plan-kit-pwa/src/features/import/ImportRoomPanel.tsx
+++ b/plan-kit-pwa/src/features/import/ImportRoomPanel.tsx
@@ -1,0 +1,78 @@
+import { ChangeEvent, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { mapRoomPlanJsonToRoom } from '../../lib/import/mapRoomPlanJsonToRoom';
+import { useProjectsStore } from '../../store/useProjectsStore';
+import { nanoid } from '../../lib/utils/nanoid';
+
+export function ImportRoomPanel() {
+  const location = useLocation();
+  const params = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const token = params.get('token');
+  const { currentPlan, updatePlan } = useProjectsStore();
+  const [status, setStatus] = useState<string>();
+
+  if (!currentPlan) {
+    return <p>Select a project first.</p>;
+  }
+
+  async function importJson(json: unknown) {
+    try {
+      const room = mapRoomPlanJsonToRoom(json);
+      const next = {
+        ...currentPlan,
+        rooms: [...currentPlan.rooms, { ...room, id: room.id ?? nanoid() }],
+        meta: { ...currentPlan.meta, updatedAt: new Date().toISOString() }
+      };
+      await updatePlan(next);
+      setStatus(`Imported room with ${room.walls.length} walls.`);
+    } catch (error) {
+      console.error(error);
+      setStatus('Failed to import room. Check console for details.');
+    }
+  }
+
+  async function handleFileUpload(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    importJson(JSON.parse(text));
+  }
+
+  async function handleFetchFromToken() {
+    if (!token) {
+      setStatus('No token provided.');
+      return;
+    }
+    setStatus('Fetching room payload…');
+    try {
+      if (!import.meta.env.VITE_USE_BACKEND) {
+        const fixture = await import('../../lib/import/fixtures/sample-room.json');
+        await importJson(fixture.default);
+        setStatus('Backend disabled; loaded sample fixture.');
+        return;
+      }
+      const response = await fetch(`/api/import/${token}`).then((res) => res.json());
+      await importJson(response);
+    } catch (error) {
+      console.error(error);
+      setStatus('Failed to fetch token payload.');
+    }
+  }
+
+  return (
+    <section className="card import-panel">
+      <h2>Import Room</h2>
+      <p>Import JSON exported by the iOS capture helper or use an upload token.</p>
+      <div className="actions">
+        <label className="secondary">
+          <input type="file" accept="application/json" onChange={handleFileUpload} hidden />
+          Upload JSON
+        </label>
+        <button className="secondary" onClick={handleFetchFromToken}>
+          Fetch from Token
+        </button>
+      </div>
+      {status && <p className="status">{status}</p>}
+    </section>
+  );
+}

--- a/plan-kit-pwa/src/features/import/ProjectsList.tsx
+++ b/plan-kit-pwa/src/features/import/ProjectsList.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useProjectsStore } from '../../store/useProjectsStore';
+
+export function ProjectsList() {
+  const navigate = useNavigate();
+  const { projects, loadProjects, createProject, removeProject } = useProjectsStore();
+  const [creating, setCreating] = useState(false);
+
+  useEffect(() => {
+    loadProjects();
+  }, [loadProjects]);
+
+  async function handleCreate() {
+    setCreating(true);
+    const plan = await createProject('New Floor Plan');
+    setCreating(false);
+    navigate(`/plan/${plan.id}`);
+  }
+
+  return (
+    <div className="projects-list">
+      <div className="list-header">
+        <h1>Projects</h1>
+        <button className="primary" onClick={handleCreate} disabled={creating}>
+          {creating ? 'Creating…' : 'New Project'}
+        </button>
+      </div>
+      <div className="grid">
+        {projects.map((project) => (
+          <article key={project.id} className="card">
+            <header>
+              <h2>{project.label ?? 'Untitled Project'}</h2>
+              <span className="timestamp">
+                Updated {new Date(project.meta.updatedAt).toLocaleString()}
+              </span>
+            </header>
+            <footer>
+              <button className="primary" onClick={() => navigate(`/plan/${project.id}`)}>
+                Open
+              </button>
+              <button className="secondary" onClick={() => removeProject(project.id)}>
+                Delete
+              </button>
+            </footer>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/plan-kit-pwa/src/features/stitch/StitchAssistant.tsx
+++ b/plan-kit-pwa/src/features/stitch/StitchAssistant.tsx
@@ -1,0 +1,113 @@
+import { useMemo, useState } from 'react';
+import { computeTransformFromSharedOpening } from '../../lib/geometry/transforms';
+import { useProjectsStore } from '../../store/useProjectsStore';
+
+export function StitchAssistant() {
+  const { currentPlan, updatePlan } = useProjectsStore();
+  const [roomAId, setRoomAId] = useState<string>();
+  const [roomBId, setRoomBId] = useState<string>();
+  const [openingAId, setOpeningAId] = useState<string>();
+  const [openingBId, setOpeningBId] = useState<string>();
+  const [status, setStatus] = useState('Select rooms and openings to align.');
+
+  const rooms = currentPlan?.rooms ?? [];
+
+  const roomOpenings = useMemo(() => {
+    return rooms.reduce<Record<string, { id: string; label: string }[]>>((acc, room) => {
+      acc[room.id] = room.walls.flatMap((wall) =>
+        wall.openings.map((opening) => ({
+          id: opening.id,
+          label: `${opening.type} · ${Math.round(opening.width_mm)} mm`
+        }))
+      );
+      return acc;
+    }, {});
+  }, [rooms]);
+
+  async function handleCompute() {
+    if (!currentPlan || !roomAId || !roomBId || !openingAId || !openingBId) {
+      setStatus('Please select two rooms and openings.');
+      return;
+    }
+    const roomA = rooms.find((room) => room.id === roomAId);
+    const roomB = rooms.find((room) => room.id === roomBId);
+    if (!roomA || !roomB) {
+      setStatus('Rooms not found.');
+      return;
+    }
+    try {
+      const transform = computeTransformFromSharedOpening(roomA, roomB, openingAId, openingBId);
+      const next = {
+        ...currentPlan,
+        transforms: {
+          ...currentPlan.transforms,
+          [roomB.id]: transform
+        },
+        meta: { ...currentPlan.meta, updatedAt: new Date().toISOString() }
+      };
+      await updatePlan(next);
+      setStatus(`Aligned rooms. Rotation ${transform.rotation_deg.toFixed(1)}°, translation ${Math.round(transform.translate.x)} × ${Math.round(transform.translate.y)} mm.`);
+    } catch (error) {
+      console.error(error);
+      setStatus('Failed to compute transform.');
+    }
+  }
+
+  if (!currentPlan) {
+    return <p>No project selected.</p>;
+  }
+
+  if (!rooms.length) {
+    return <p>Import rooms first.</p>;
+  }
+
+  return (
+    <section className="card stitch-assistant">
+      <h2>Stitch Rooms</h2>
+      <div className="grid-2">
+        <div>
+          <h3>Room A</h3>
+          <select value={roomAId ?? ''} onChange={(e) => setRoomAId(e.target.value)}>
+            <option value="">Select room</option>
+            {rooms.map((room) => (
+              <option key={room.id} value={room.id}>
+                {room.name ?? `Room ${room.id.slice(0, 4)}`}
+              </option>
+            ))}
+          </select>
+          <select value={openingAId ?? ''} onChange={(e) => setOpeningAId(e.target.value)}>
+            <option value="">Select opening</option>
+            {(roomAId && roomOpenings[roomAId])?.map((opening) => (
+              <option key={opening.id} value={opening.id}>
+                {opening.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <h3>Room B</h3>
+          <select value={roomBId ?? ''} onChange={(e) => setRoomBId(e.target.value)}>
+            <option value="">Select room</option>
+            {rooms.map((room) => (
+              <option key={room.id} value={room.id}>
+                {room.name ?? `Room ${room.id.slice(0, 4)}`}
+              </option>
+            ))}
+          </select>
+          <select value={openingBId ?? ''} onChange={(e) => setOpeningBId(e.target.value)}>
+            <option value="">Select opening</option>
+            {(roomBId && roomOpenings[roomBId])?.map((opening) => (
+              <option key={opening.id} value={opening.id}>
+                {opening.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <button className="primary" onClick={handleCompute}>
+        Compute Transform
+      </button>
+      <p className="status">{status}</p>
+    </section>
+  );
+}

--- a/plan-kit-pwa/src/lib/exporters/csv.ts
+++ b/plan-kit-pwa/src/lib/exporters/csv.ts
@@ -1,0 +1,30 @@
+import { lineLength } from '../geometry/vector';
+import { applyTransformToRoom } from '../geometry/transforms';
+import { FloorPlan } from '../../types/models';
+
+export async function exportAsCsv(plan: FloorPlan) {
+  const rooms = plan.rooms.map((room) => {
+    const transform = plan.transforms[room.id];
+    return transform ? applyTransformToRoom(room, transform) : room;
+  });
+
+  const doorWindowLines = ['room_id,opening_id,type,width_mm,height_mm,position_mm'];
+  rooms.forEach((room) => {
+    room.walls.forEach((wall) => {
+      wall.openings.forEach((opening) => {
+        doorWindowLines.push(
+          [room.id, opening.id, opening.type, opening.width_mm, opening.height_mm ?? '', opening.position_along_wall_mm].join(',')
+        );
+      });
+    });
+  });
+
+  const roomLines = ['room_id,area_mm2,perimeter_mm'];
+  rooms.forEach((room) => {
+    const perimeter = room.walls.reduce((sum, wall) => sum + lineLength(wall.start, wall.end), 0);
+    roomLines.push([room.id, 'TODO_AREA', Math.round(perimeter)].join(','));
+  });
+
+  const csv = ['# openings', ...doorWindowLines, '', '# rooms', ...roomLines].join('\n');
+  return new Blob([csv], { type: 'text/csv' });
+}

--- a/plan-kit-pwa/src/lib/exporters/dxf.ts
+++ b/plan-kit-pwa/src/lib/exporters/dxf.ts
@@ -1,0 +1,26 @@
+import DXFWriter, { Colors } from 'dxf-writer';
+import { applyTransformToRoom } from '../geometry/transforms';
+import { FloorPlan } from '../../types/models';
+
+export async function exportAsDxf(plan: FloorPlan) {
+  const writer = new DXFWriter();
+  writer.addLayer('WALLS', Colors.White, 'CONTINUOUS');
+  writer.addLayer('DOORS', Colors.Green, 'CONTINUOUS');
+  writer.addLayer('WINDOWS', Colors.Cyan, 'CONTINUOUS');
+
+  plan.rooms.forEach((room) => {
+    const transformed = plan.transforms[room.id] ? applyTransformToRoom(room, plan.transforms[room.id]) : room;
+    transformed.walls.forEach((wall) => {
+      writer.setCurrentLayer('WALLS');
+      writer.drawLine(wall.start.x, wall.start.y, 0, wall.end.x, wall.end.y, 0);
+      wall.openings.forEach((opening) => {
+        const layer = opening.type === 'door' ? 'DOORS' : 'WINDOWS';
+        writer.setCurrentLayer(layer);
+        writer.drawCircle(wall.start.x, wall.start.y, 0, opening.position_along_wall_mm + opening.width_mm / 2);
+      });
+    });
+  });
+
+  const dxf = writer.stringify();
+  return new Blob([dxf], { type: 'application/dxf' });
+}

--- a/plan-kit-pwa/src/lib/exporters/pdf.ts
+++ b/plan-kit-pwa/src/lib/exporters/pdf.ts
@@ -1,0 +1,45 @@
+import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
+import { FloorPlan } from '../../types/models';
+import { applyTransformToRoom } from '../geometry/transforms';
+
+export async function exportAsPdf(plan: FloorPlan) {
+  const pdf = await PDFDocument.create();
+  const page = pdf.addPage([842, 595]); // A4 landscape
+  const { height } = page.getSize();
+  const font = await pdf.embedFont(StandardFonts.Helvetica);
+
+  page.drawText('PlanKit Floor Plan', {
+    x: 40,
+    y: height - 40,
+    size: 18,
+    font,
+    color: rgb(0.1, 0.1, 0.1)
+  });
+
+  page.drawText(`Project: ${plan.label ?? plan.id}`, { x: 40, y: height - 70, size: 12, font });
+  page.drawText(`Updated: ${new Date(plan.meta.updatedAt).toLocaleString()}`, {
+    x: 40,
+    y: height - 90,
+    size: 10,
+    font
+  });
+
+  const rooms = plan.rooms.map((room) => {
+    const transform = plan.transforms[room.id];
+    return transform ? applyTransformToRoom(room, transform) : room;
+  });
+
+  let offsetY = height - 130;
+  rooms.forEach((room) => {
+    page.drawText(`${room.name ?? room.id} · walls: ${room.walls.length}`, {
+      x: 40,
+      y: offsetY,
+      size: 10,
+      font
+    });
+    offsetY -= 16;
+  });
+
+  const pdfBytes = await pdf.save();
+  return new Blob([pdfBytes], { type: 'application/pdf' });
+}

--- a/plan-kit-pwa/src/lib/exporters/saveAs.ts
+++ b/plan-kit-pwa/src/lib/exporters/saveAs.ts
@@ -1,0 +1,8 @@
+export function saveAs(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}

--- a/plan-kit-pwa/src/lib/exporters/svg.ts
+++ b/plan-kit-pwa/src/lib/exporters/svg.ts
@@ -1,0 +1,19 @@
+import { applyTransformToRoom } from '../geometry/transforms';
+import { FloorPlan } from '../../types/models';
+
+export async function exportAsSvg(plan: FloorPlan) {
+  const rooms = plan.rooms.map((room) => {
+    const transform = plan.transforms[room.id];
+    return transform ? applyTransformToRoom(room, transform) : room;
+  });
+  const paths = rooms
+    .map((room) => {
+      const d = room.walls
+        .map((wall, index) => `${index === 0 ? 'M' : 'L'} ${wall.start.x} ${wall.start.y}`)
+        .join(' ');
+      return `<path d="${d} Z" fill="none" stroke="#111827" stroke-width="${room.walls[0]?.thickness_mm ?? 120}" />`;
+    })
+    .join('\n');
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8000 6000">${paths}</svg>`;
+  return new Blob([svg], { type: 'image/svg+xml' });
+}

--- a/plan-kit-pwa/src/lib/geometry/transforms.ts
+++ b/plan-kit-pwa/src/lib/geometry/transforms.ts
@@ -1,0 +1,66 @@
+import { Opening, Room, Vec2 } from '../../types/models';
+import { rotate, translate } from './vector';
+
+type Transform = { rotation_deg: number; translate: Vec2 };
+
+type OpeningReference = {
+  wallDirection: Vec2;
+  center: Vec2;
+  opening: Opening;
+};
+
+function findOpening(room: Room, openingId: string): OpeningReference | undefined {
+  for (const wall of room.walls) {
+    const start = wall.start;
+    const end = wall.end;
+    const direction = { x: end.x - start.x, y: end.y - start.y };
+    const wallLength = Math.hypot(direction.x, direction.y);
+    const normalised = { x: direction.x / wallLength, y: direction.y / wallLength };
+    for (const opening of wall.openings) {
+      if (opening.id === openingId) {
+        const centerOffset = opening.position_along_wall_mm + opening.width_mm / 2;
+        const center: Vec2 = {
+          x: start.x + normalised.x * centerOffset,
+          y: start.y + normalised.y * centerOffset
+        };
+        return { wallDirection: normalised, center, opening };
+      }
+    }
+  }
+  return undefined;
+}
+
+export function computeTransformFromSharedOpening(
+  roomA: Room,
+  roomB: Room,
+  openingIdA: string,
+  openingIdB: string
+): Transform {
+  const refA = findOpening(roomA, openingIdA);
+  const refB = findOpening(roomB, openingIdB);
+  if (!refA || !refB) {
+    throw new Error('Shared openings not found');
+  }
+  const angleA = Math.atan2(refA.wallDirection.y, refA.wallDirection.x);
+  const angleB = Math.atan2(refB.wallDirection.y, refB.wallDirection.x);
+  const rotation = ((angleA - angleB) * 180) / Math.PI;
+  const rotatedCenterB = rotate(refB.center, rotation, refB.center);
+  const translation = {
+    x: refA.center.x - rotatedCenterB.x,
+    y: refA.center.y - rotatedCenterB.y
+  };
+  return { rotation_deg: rotation, translate: translation };
+}
+
+export function applyTransformToRoom(room: Room, transform: Transform): Room {
+  const rotation = transform.rotation_deg;
+  const translateVec = transform.translate;
+  return {
+    ...room,
+    walls: room.walls.map((wall) => ({
+      ...wall,
+      start: translate(rotate(wall.start, rotation), translateVec),
+      end: translate(rotate(wall.end, rotation), translateVec)
+    }))
+  };
+}

--- a/plan-kit-pwa/src/lib/geometry/vector.ts
+++ b/plan-kit-pwa/src/lib/geometry/vector.ts
@@ -1,0 +1,26 @@
+import { Vec2 } from '../../types/models';
+
+export function lineLength(start: Vec2, end: Vec2) {
+  return Math.hypot(end.x - start.x, end.y - start.y);
+}
+
+export function angleBetween(a: Vec2, b: Vec2) {
+  const dot = a.x * b.x + a.y * b.y;
+  const det = a.x * b.y - a.y * b.x;
+  return (Math.atan2(det, dot) * 180) / Math.PI;
+}
+
+export function rotate(point: Vec2, degrees: number, origin: Vec2 = { x: 0, y: 0 }): Vec2 {
+  const rad = (degrees * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const translated = { x: point.x - origin.x, y: point.y - origin.y };
+  return {
+    x: translated.x * cos - translated.y * sin + origin.x,
+    y: translated.x * sin + translated.y * cos + origin.y
+  };
+}
+
+export function translate(point: Vec2, vec: Vec2): Vec2 {
+  return { x: point.x + vec.x, y: point.y + vec.y };
+}

--- a/plan-kit-pwa/src/lib/import/fixtures/sample-room.json
+++ b/plan-kit-pwa/src/lib/import/fixtures/sample-room.json
@@ -1,0 +1,41 @@
+{
+  "room": {
+    "height_m": 2.5,
+    "walls": [
+      {
+        "start": { "x": 0.0, "y": 0.0 },
+        "end": { "x": 4000.0, "y": 0.0 },
+        "thickness_mm": 120,
+        "openings": [
+          { "type": "door", "width_mm": 800, "height_mm": 2030, "position_along_wall_mm": 500, "swing": "R" }
+        ]
+      },
+      {
+        "start": { "x": 4000.0, "y": 0.0 },
+        "end": { "x": 4000.0, "y": 3000.0 },
+        "thickness_mm": 120,
+        "openings": []
+      },
+      {
+        "start": { "x": 4000.0, "y": 3000.0 },
+        "end": { "x": 0.0, "y": 3000.0 },
+        "thickness_mm": 120,
+        "openings": [
+          {
+            "type": "window",
+            "width_mm": 1200,
+            "height_mm": 1200,
+            "sill_height_mm": 900,
+            "position_along_wall_mm": 1000
+          }
+        ]
+      },
+      {
+        "start": { "x": 0.0, "y": 3000.0 },
+        "end": { "x": 0.0, "y": 0.0 },
+        "thickness_mm": 120,
+        "openings": []
+      }
+    ]
+  }
+}

--- a/plan-kit-pwa/src/lib/import/mapRoomPlanJsonToRoom.ts
+++ b/plan-kit-pwa/src/lib/import/mapRoomPlanJsonToRoom.ts
@@ -1,0 +1,65 @@
+import { nanoid } from '../utils/nanoid';
+import { Opening, Room, Wall } from '../../types/models';
+
+type RoomPlanOpening = {
+  type: 'door' | 'window';
+  width_mm: number;
+  height_mm?: number;
+  sill_height_mm?: number;
+  position_along_wall_mm: number;
+  swing?: 'L' | 'R' | 'slider' | 'fixed';
+};
+
+type RoomPlanWall = {
+  start: { x: number; y: number };
+  end: { x: number; y: number };
+  thickness_mm: number;
+  openings: RoomPlanOpening[];
+};
+
+type RoomPlanRoom = {
+  name?: string;
+  height_m?: number;
+  walls: RoomPlanWall[];
+};
+
+type RoomPlanPayload = {
+  room: RoomPlanRoom;
+};
+
+function asMillimetres(value: number) {
+  return Math.round(value);
+}
+
+export function mapRoomPlanJsonToRoom(json: unknown): Room {
+  const payload = json as RoomPlanPayload;
+  if (!payload?.room?.walls) {
+    throw new Error('Invalid RoomPlan payload');
+  }
+
+  const walls: Wall[] = payload.room.walls.map((wall) => ({
+    id: nanoid(),
+    start: { x: asMillimetres(wall.start.x), y: asMillimetres(wall.start.y) },
+    end: { x: asMillimetres(wall.end.x), y: asMillimetres(wall.end.y) },
+    thickness_mm: wall.thickness_mm,
+    openings: (wall.openings ?? []).map((opening): Opening => ({
+      id: nanoid(),
+      type: opening.type,
+      width_mm: opening.width_mm,
+      height_mm: opening.height_mm,
+      sill_height_mm: opening.sill_height_mm,
+      position_along_wall_mm: opening.position_along_wall_mm,
+      swing: opening.swing
+    }))
+  }));
+
+  const room: Room = {
+    id: nanoid(),
+    name: payload.room.name,
+    height_mm: payload.room.height_m ? payload.room.height_m * 1000 : undefined,
+    walls,
+    source: { roomplan: payload }
+  };
+
+  return room;
+}

--- a/plan-kit-pwa/src/lib/utils/nanoid.ts
+++ b/plan-kit-pwa/src/lib/utils/nanoid.ts
@@ -1,0 +1,10 @@
+const alphabet = '0123456789abcdefghijklmnopqrstuvwxyz';
+
+export function nanoid(length = 10) {
+  let id = '';
+  const n = alphabet.length;
+  for (let i = 0; i < length; i += 1) {
+    id += alphabet[Math.floor(Math.random() * n)];
+  }
+  return id;
+}

--- a/plan-kit-pwa/src/main.tsx
+++ b/plan-kit-pwa/src/main.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { App } from './app/App';
+import './styles.css';
+import { registerServiceWorker } from './app/registerServiceWorker';
+
+const basename = import.meta.env.BASE_URL ?? '/';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter basename={basename}>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);
+
+if (import.meta.env.PROD) {
+  registerServiceWorker();
+}

--- a/plan-kit-pwa/src/service-worker.ts
+++ b/plan-kit-pwa/src/service-worker.ts
@@ -1,0 +1,12 @@
+/// <reference lib="webworker" />
+import { precacheAndRoute } from 'workbox-precaching';
+
+declare const self: ServiceWorkerGlobalScope;
+
+precacheAndRoute(self.__WB_MANIFEST || []);
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});

--- a/plan-kit-pwa/src/store/db.ts
+++ b/plan-kit-pwa/src/store/db.ts
@@ -1,0 +1,50 @@
+import Dexie, { Table } from 'dexie';
+import { FloorPlan, Room } from '../types/models';
+
+type ProjectRecord = {
+  id: string;
+  label?: string;
+  plan: FloorPlan;
+  updatedAt: string;
+};
+
+type RoomRecord = {
+  id: string;
+  room: Room;
+  planId: string;
+  updatedAt: string;
+};
+
+class PlanKitDatabase extends Dexie {
+  projects!: Table<ProjectRecord>;
+  rooms!: Table<RoomRecord>;
+
+  constructor() {
+    super('PlanKitDB');
+    this.version(1).stores({
+      projects: '&id, updatedAt',
+      rooms: '&id, planId, updatedAt'
+    });
+  }
+}
+
+export const db = new PlanKitDatabase();
+
+export async function saveFloorPlan(plan: FloorPlan) {
+  const updatedAt = new Date().toISOString();
+  const nextPlan = { ...plan, meta: { ...plan.meta, updatedAt } };
+  await db.projects.put({ id: plan.id, label: plan.label, plan: nextPlan, updatedAt });
+  return nextPlan;
+}
+
+export async function listProjects() {
+  return db.projects.orderBy('updatedAt').reverse().toArray();
+}
+
+export async function deleteProject(id: string) {
+  await db.projects.delete(id);
+  const rooms = await db.rooms.where({ planId: id }).primaryKeys();
+  if (rooms.length) {
+    await db.rooms.bulkDelete(rooms);
+  }
+}

--- a/plan-kit-pwa/src/store/useProjectsStore.ts
+++ b/plan-kit-pwa/src/store/useProjectsStore.ts
@@ -1,0 +1,61 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { nanoid } from '../lib/utils/nanoid';
+import { FloorPlan } from '../types/models';
+import { deleteProject, listProjects, saveFloorPlan } from './db';
+
+type ProjectsState = {
+  projects: FloorPlan[];
+  loading: boolean;
+  currentPlan?: FloorPlan;
+  loadProjects: () => Promise<void>;
+  createProject: (label?: string) => Promise<FloorPlan>;
+  setCurrentPlan: (plan: FloorPlan) => void;
+  updatePlan: (plan: FloorPlan) => Promise<void>;
+  removeProject: (id: string) => Promise<void>;
+};
+
+export const useProjectsStore = create<ProjectsState>()(
+  persist(
+    (set, get) => ({
+      projects: [],
+      loading: false,
+      async loadProjects() {
+        set({ loading: true });
+        const result = await listProjects();
+        set({ projects: result.map((p) => p.plan), loading: false });
+      },
+      async createProject(label) {
+        const now = new Date().toISOString();
+        const plan: FloorPlan = {
+          id: nanoid(),
+          label: label ?? 'Untitled Project',
+          rooms: [],
+          transforms: {},
+          meta: { createdAt: now, updatedAt: now }
+        };
+        const persisted = await saveFloorPlan(plan);
+        set({ projects: [...get().projects, persisted], currentPlan: persisted });
+        return persisted;
+      },
+      setCurrentPlan(plan) {
+        set({ currentPlan: plan });
+      },
+      async updatePlan(plan) {
+        const persisted = await saveFloorPlan(plan);
+        set({
+          projects: get().projects.map((p) => (p.id === persisted.id ? persisted : p)),
+          currentPlan: persisted
+        });
+      },
+      async removeProject(id) {
+        await deleteProject(id);
+        set({ projects: get().projects.filter((p) => p.id !== id) });
+      }
+    }),
+    {
+      name: 'plankit-state',
+      partialize: (state) => ({ projects: state.projects, currentPlan: state.currentPlan })
+    }
+  )
+);

--- a/plan-kit-pwa/src/styles.css
+++ b/plan-kit-pwa/src/styles.css
@@ -1,0 +1,163 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f8fafc;
+  color: #0f172a;
+}
+
+body {
+  margin: 0;
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  font: inherit;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: #1f2937;
+  color: #f8fafc;
+}
+
+.app-header a {
+  text-decoration: none;
+  color: inherit;
+  margin-left: 1rem;
+}
+
+.app-header .brand {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.app-main {
+  flex: 1;
+  padding: 1.5rem;
+}
+
+.projects-list .list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.projects-list .grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.projects-list article footer {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.workspace-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.workspace-tabs {
+  display: flex;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.workspace-tabs a {
+  text-decoration: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 8px;
+  color: #1f2937;
+  background: rgba(15, 23, 42, 0.06);
+}
+
+.workspace-tabs a.active {
+  background: #1d4ed8;
+  color: white;
+}
+
+.workspace-content {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.import-panel .actions,
+.export-panel .actions,
+.stitch-assistant .grid-2 {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.stitch-assistant select {
+  width: 200px;
+  padding: 0.4rem;
+}
+
+.canvas-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 1.5rem;
+}
+
+.canvas-workspace .toolbar {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.canvas-workspace .room-metrics ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.canvas-workspace .room-metrics li + li {
+  margin-top: 0.5rem;
+}
+
+.primary {
+  background: #1d4ed8;
+  color: white;
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.secondary {
+  background: transparent;
+  border: 1px solid #1d4ed8;
+  color: #1d4ed8;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+}

--- a/plan-kit-pwa/src/types/models.ts
+++ b/plan-kit-pwa/src/types/models.ts
@@ -1,0 +1,38 @@
+export type ID = string;
+export type Vec2 = { x: number; y: number };
+
+export type OpeningType = 'door' | 'window';
+
+export type Opening = {
+  id: ID;
+  type: OpeningType;
+  width_mm: number;
+  height_mm?: number;
+  sill_height_mm?: number;
+  position_along_wall_mm: number;
+  swing?: 'L' | 'R' | 'slider' | 'fixed';
+};
+
+export type Wall = {
+  id: ID;
+  start: Vec2;
+  end: Vec2;
+  thickness_mm: number;
+  openings: Opening[];
+};
+
+export type Room = {
+  id: ID;
+  name?: string;
+  walls: Wall[];
+  height_mm?: number;
+  source?: { roomplan?: unknown };
+};
+
+export type FloorPlan = {
+  id: ID;
+  label?: string;
+  rooms: Room[];
+  transforms: Record<ID, { rotation_deg: number; translate: Vec2 }>;
+  meta: { createdAt: string; updatedAt: string; address?: string };
+};

--- a/plan-kit-pwa/src/vite-env.d.ts
+++ b/plan-kit-pwa/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_USE_BACKEND?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/plan-kit-pwa/tsconfig.json
+++ b/plan-kit-pwa/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/plan-kit-pwa/tsconfig.node.json
+++ b/plan-kit-pwa/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts", "service-worker.ts"]
+}

--- a/plan-kit-pwa/vite.config.ts
+++ b/plan-kit-pwa/vite.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { VitePWA } from 'vite-plugin-pwa';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    VitePWA({
+      strategies: 'injectManifest',
+      srcDir: 'src',
+      filename: 'service-worker.ts',
+      injectRegister: false,
+      workbox: {
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,webmanifest}'],
+      },
+    }),
+  ],
+  server: {
+    port: 5173,
+  },
+  build: {
+    sourcemap: true,
+  }
+});


### PR DESCRIPTION
## Summary
- register the service worker using the deployment base URL to avoid 404s on non-root hosts
- move the Workbox service worker into the Vite build and configure vite-plugin-pwa to emit it with precaching
- add required PWA type references and dependencies for the Workbox runtime

## Testing
- npm install *(fails: registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d853c0d03c8332a08f389098075828